### PR TITLE
Update evaluate InfPool readiness

### DIFF
--- a/pkg/apis/serving/v1alpha1/llm_inference_service_lifecycle.go
+++ b/pkg/apis/serving/v1alpha1/llm_inference_service_lifecycle.go
@@ -39,9 +39,9 @@ const (
 )
 
 const (
-	GatewaysReady       apis.ConditionType = "GatewaysReady"
-	HTTPRoutesReady     apis.ConditionType = "HTTPRoutesReady"
-	InferencePoolsReady apis.ConditionType = "InferencePoolsReady"
+	GatewaysReady      apis.ConditionType = "GatewaysReady"
+	HTTPRoutesReady    apis.ConditionType = "HTTPRoutesReady"
+	InferencePoolReady apis.ConditionType = "InferencePoolReady"
 )
 
 var llmInferenceServiceCondSet = apis.NewLivingConditionSet(
@@ -141,19 +141,19 @@ func (in *LLMInferenceService) MarkHTTPRoutesNotReady(reason, messageFormat stri
 	in.GetConditionSet().Manage(in.GetStatus()).MarkFalse(HTTPRoutesReady, reason, messageFormat, messageA...)
 }
 
-func (in *LLMInferenceService) MarkInferencePoolsReady() {
-	in.GetConditionSet().Manage(in.GetStatus()).MarkTrue(InferencePoolsReady)
+func (in *LLMInferenceService) MarkInferencePoolReady() {
+	in.GetConditionSet().Manage(in.GetStatus()).MarkTrue(InferencePoolReady)
 }
 
-func (in *LLMInferenceService) MarkInferencePoolsNotReady(reason, messageFormat string, messageA ...interface{}) {
-	in.GetConditionSet().Manage(in.GetStatus()).MarkFalse(InferencePoolsReady, reason, messageFormat, messageA...)
+func (in *LLMInferenceService) MarkInferencePoolNotReady(reason, messageFormat string, messageA ...interface{}) {
+	in.GetConditionSet().Manage(in.GetStatus()).MarkFalse(InferencePoolReady, reason, messageFormat, messageA...)
 }
 
 func (in *LLMInferenceService) DetermineRouterReadiness() {
 	subConditions := []*apis.Condition{
 		in.GetStatus().GetCondition(GatewaysReady),
 		in.GetStatus().GetCondition(HTTPRoutesReady),
-		in.GetStatus().GetCondition(InferencePoolsReady),
+		in.GetStatus().GetCondition(InferencePoolReady),
 		in.GetStatus().GetCondition(SchedulerWorkloadReady),
 	}
 

--- a/pkg/controller/llmisvc/fixture/gwapi_builders.go
+++ b/pkg/controller/llmisvc/fixture/gwapi_builders.go
@@ -591,9 +591,10 @@ func WithInferencePoolReadyStatus() InferencePoolOption {
 			{
 				Conditions: []metav1.Condition{
 					{
-						Type:   string(igwapi.InferencePoolConditionAccepted),
-						Status: metav1.ConditionTrue,
-						Reason: string(igwapi.InferencePoolReasonAccepted),
+						Type:               string(igwapi.InferencePoolConditionAccepted),
+						Status:             metav1.ConditionTrue,
+						Reason:             string(igwapi.InferencePoolReasonAccepted),
+						LastTransitionTime: metav1.Now(),
 					},
 				},
 			},


### PR DESCRIPTION
- InferencePool is only one (either a ref or a embedded Spec)
- Updated ensureRouterManagedResourcesAreReady to also make InfPool ready
- Update logic for IsInferencePoolReady to be consistent with the HTTPRoute logic and evaluate all parents to be Accepted
- Removed the embedded InfPool test as it's already covered in other schenarios where `Scheduler != nil`
- Fixed tests

Feel free to review, ask questions and make changes, once we merge this PR, the original PR will get updated automatically